### PR TITLE
Add commons math3 to juicer_tools artifact

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -336,6 +336,7 @@
                         prefix="META-INF"/>
             <zipfileset dir="${juicebox.output.dir}"/>
             <zipfileset src="${basedir}/lib/general/jsi1.1.jar" excludes="META-INF/*.SF,META-INF/*.DSA,META-INF/*.RSA"/>
+            <zipfileset src="${basedir}/lib/general/commons-math3-3.6.1.jar"/>
             <zipfileset src="${basedir}/lib/general/guava-18.0.jar"/>
             <zipfileset src="${basedir}/lib/general/VectorGraphics2D-0.11.jar"/>
             <zipfileset src="${basedir}/lib/broadinstitute/igv.jar"


### PR DESCRIPTION
When running via the latest version of juicer, without this it will fail at the hic/hic30 steps as unable to find a math3 class in the tools jar. Java isn't my forte, so maybe we just had it configured wrong.